### PR TITLE
Force opaque tabbar hack

### DIFF
--- a/Meshtastic/Views/ContentView.swift
+++ b/Meshtastic/Views/ContentView.swift
@@ -54,5 +54,8 @@ struct ContentView: View {
 			.tag(NavigationState.Tab.settings)
 		}
 		.toolbarBackground(.visible, for: .tabBar)
+		.onAppear {
+			UITabBar.appearance().scrollEdgeAppearance = UITabBarAppearance.init(idiom: .unspecified)
+		}
 	}
 }


### PR DESCRIPTION
hack to force the tabbar to always be shown. i think its against the latest hig, but the correct solution I havent had time to learn.